### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,22 +6,22 @@
 # Datatypes (KEYWORD1) Classes
 #######################################
 
-ThingerClient   KEYWORD1
-ThingerEthernet KEYWORD1
-ThingerWifi KEYWORD1
-ThingerYun  KEYWORD1
-pson    KEYWORD1
+ThingerClient	KEYWORD1
+ThingerEthernet	KEYWORD1
+ThingerWifi	KEYWORD1
+ThingerYun	KEYWORD1
+pson	KEYWORD1
 
 #######################################
 # Datatypes (KEYWORD2) Methods
 #######################################
 
-in  KEYWORD2
-out KEYWORD2
+in	KEYWORD2
+out	KEYWORD2
 
 #######################################
 # Datatypes (KEYWORD3) Setup & Loop
 #######################################
 
-add_wifi    KEYWORD3
-handle  KEYWORD3
+add_wifi	KEYWORD3
+handle	KEYWORD3


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords